### PR TITLE
Rename all references to juliaogris github user to OfficiallyEQL

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 brews:
   - tap:
-      owner: juliaogris
+      owner: OfficiallyEQL
       name: homebrew-tap
       branch: master
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
@@ -10,7 +10,7 @@ brews:
       email: bot@goreleaser.com
 
     commit_msg_template: "Update brew formula for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: "https://github.com/juliaogris/orderer"
+    homepage: "https://github.com/OfficiallyEQL/orderer"
     description: "orderer is a CLI for importing orders into shopify."
     license: "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 Install `orderer` with
 
-	brew tap juliaogris/tap
+	brew tap OfficiallyEQL/tap
 	brew install orderer
 
-Alternatively you can download the executable directly from [releases](https://github.com/juliaogris/orderer/releases) or install with `go install github.com/juliaogris/orderer@latest`
+Alternatively you can download the executable directly from [releases](https://github.com/OfficiallyEQL/orderer/releases) or install with `go install github.com/OfficiallyEQL/orderer@latest`
 
 After installation try
 
@@ -21,7 +21,7 @@ After installation try
 	orderer create testdata/order.json
 	orderer list testdata/order.json
 
-[releases]: https://github.com/juliaogris/orderer/releases
+[releases]: https://github.com/OfficiallyEQL/orderer/releases
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juliaogris/orderer
+module github.com/OfficiallyEQL/orderer
 
 go 1.19
 

--- a/testdata/order.json
+++ b/testdata/order.json
@@ -5,12 +5,11 @@
     "line_items":
     [
         {
-            "product_id": 7974172852512,
-            "title": "Medium",
-            "sku": "gdck-m",
+            "product_id": 7838378262746,
+            "title": "Unit test shoe",
             "quantity": 1,
-            "price": 15,
-            "total": 15
+            "price": 1,
+            "total": 1
         }
     ]
 }


### PR DESCRIPTION
Rename all references to juliaogris github user to OfficiallyEQL as we
have moved the repo the EQL's GitHub org.