### PR TITLE
Fix orderer release process for brew

### DIFF
--- a/.github/scripts/app_token
+++ b/.github/scripts/app_token
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Generate temporary installation token for GitHub App
+#
+# The following environment variables are required
+# 1. GITHUB_APP_ID:  number
+# 2. GITHUB_APP_PEM: contents of the App's private key.
+main() {
+	set -euo pipefail
+	on_ci && set -x
+	validate_env
+
+	jwt=$(make_jwt)
+	resp=$(curl -s -H "Authorization: Bearer ${jwt}" -H "Accept: application/vnd.github+json" https://api.github.com/app/installations)
+	installation_id=$(jq "${validate_installation_jq}" <<<"${resp}")
+
+	resp=$(curl -s -X POST -H "Authorization: Bearer ${jwt}" -H "Accept: application/vnd.github+json" "https://api.github.com/app/installations/${installation_id}/access_tokens")
+	jq -r "${validate_token_jq}" <<<"${resp}"
+}
+
+validate_env() {
+	if [[ -z ${GITHUB_APP_ID:-} ]]; then
+		exit_error "GITHUB_APP_ID is not set"
+	fi
+	if ! [[ ${GITHUB_APP_ID:-} =~ ^[0-9]+$ ]]; then
+		exit_error "GITHUB_APP_ID is not a number"
+	fi
+	if [[ -z ${GITHUB_APP_PEM:-} ]]; then
+		exit_error "GITHUB_APP_PEM is not set"
+	fi
+}
+
+make_jwt() {
+	local now drift iat exp iss header payload signature
+	now=$(date +%s)
+	drift=10
+	# iat is the "issued at time".
+	iat=$((now - drift))
+	# exp is the JWT expiration time (max 10m).
+	exp=$((now + 600 - drift))
+	iss=${GITHUB_APP_ID}
+
+	header=$(printf '%s' '{"alg":"RS256"}' | base64url)
+	payload=$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "${iat}" "${exp}" "${iss}" | base64url)
+	signature=$(printf '%s.%s' "${header}" "${payload}" | openssl dgst -sha256 -sign <(printenv GITHUB_APP_PEM) | base64url)
+	echo "${header}.${payload}.${signature}"
+}
+
+on_ci() {
+	[[ -n "${CI:-}" ]]
+}
+
+exit_error() {
+	echo "$1" >&2
+	exit 1
+}
+
+# base64url encodes with base64 encoding then replaces `+` with `-`,
+# `/` with `_` and strips trailing `=`
+base64url() {
+	# Use `openssl enc -A -base64` instead of `base64` because `base64`
+	# adds linebreaks on linux but not on mac. The flag to change this doesn't work on mac.
+	openssl enc -A -base64 | sed -e 'y|+/|-_|' -e 's/=*$//'
+}
+
+validate_installation_jq='
+if type != "array" then
+	"installations response is not array.\n" | halt_error
+elif length != 1 then
+	"expected exactly 1 installation\n" | halt_error
+elif .[0].id | type != "number" then
+	"installation id is not a number\n" | halt_error
+else
+	.[0].id
+end'
+
+validate_token_jq='
+if .token | type != "string" then
+	"token is not a string.\n" | halt_error
+else
+	.token
+end'
+
+# Only run main if executed as a script and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: ./.github/scripts/app_token #TODO: remove, just for testing
+      env:
+        GITHUB_APP_ID: ${{ secrets.APPNAME_GITHUB_APP_ID }}
+        GITHUB_APP_PEM: ${{ secrets.APPNAME_GITHUB_APP_PEM }}
     - run: ./bin/make ci
 
   release:
@@ -27,4 +31,5 @@ jobs:
     - run: ./bin/make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        GITHUB_APP_ID: ${{ secrets.APPNAME_GITHUB_APP_ID }}
+        GITHUB_APP_PEM: ${{ secrets.APPNAME_GITHUB_APP_PEM }}

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ lint: ## Lint go source code
 release: nexttag ## Tag and release binaries for different OS on GitHub release
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)
+	[ -z "$(CI)" ] || GITHUB_TOKEN=$$(.github/scripts/app_token) || exit 1; \
 	goreleaser release --rm-dist
 
 nexttag:


### PR DESCRIPTION
Fix orderer release process for brew by creating temporary access token
for a GitHub app that pushes an updated formula to https://github.com/OfficiallyEQL/homebrew-tap