### PR TITLE
Fix release process (again)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,6 @@ brews:
       owner: OfficiallyEQL
       name: homebrew-tap
       branch: master
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
 
     commit_author:
       name: goreleaserbot

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ type GetCmd struct {
 
 type ListCmd struct {
 	Config
-	Order *goshopify.Order `arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order name to be listed (only name matters)"`
+	Order *goshopify.Order `optional:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order name to be listed (only name matters)"`
 	Name  string
 }
 
@@ -75,7 +75,7 @@ type UpdateCmd struct {
 
 type DeleteCmd struct {
 	Config
-	Order  *goshopify.Order `required:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order to be deleted"`
+	Order  *goshopify.Order `optional:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order to be deleted"`
 	Name   string
 	Unique bool `short:"u" help:"assert order name is used at most once"`
 }

--- a/main_test.go
+++ b/main_test.go
@@ -81,7 +81,7 @@ func TestRun(t *testing.T) {
 
 func testConfig(t *testing.T, out io.Writer) *Config {
 	t.Helper()
-	store := getenv(t, "SHOPIFY_STORE")
+	store := "eql-dev"
 	token := getenv(t, "SHOPIFY_TOKEN")
 	logger := NewLogger(io.Discard, LogLevelDebug)
 	opts := []goshopify.Option{


### PR DESCRIPTION
Fix release process (again), hopefully this time for the last time by
removing the reference special `TAP_GITHUB_TOKEN`, as we now encode the
access token for homebrew formula update in the more idiomatic
`GITHUB_TOKEN`.

While at it, hard-code the shopify store name as we are about to make
tests depend on `eql-dev` shopify store for product verification.

Fix command line argument specs to make the order.json file argument
optional in commands `list` and `delete` as the order may also be
identified via the `--name` flag.