### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,7 @@ brews:
   - tap:
       owner: OfficiallyEQL
       name: homebrew-tap
-      branch: master
+      branch: main
 
     commit_author:
       name: goreleaserbot


### PR DESCRIPTION
Fix goreleaser config yet again, this time accomodating the default
branch on OfficiallyEQL/homebrew-tap to be `main` not `master`.