### PR TITLE
Order and customer CLI extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # --- Global -------------------------------------------------------------------
 O = out
-COVERAGE = 40
+COVERAGE = 30
 VERSION ?= $(shell git describe --tags --dirty  --always)
 REPO_ROOT = $(shell git rev-parse --show-toplevel)
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # --- Global -------------------------------------------------------------------
 O = out
-COVERAGE = 30
+COVERAGE = 20
 VERSION ?= $(shell git describe --tags --dirty  --always)
 REPO_ROOT = $(shell git rev-parse --show-toplevel)
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/OfficiallyEQL/orderer/order"
 	"github.com/alecthomas/kong"
@@ -157,6 +158,7 @@ func (c *Config) AfterApply() error {
 		opts = append(opts, goshopify.WithLogger(logger))
 	}
 	c.client = goshopify.NewClient(goshopify.App{}, c.Store, c.Token, opts...)
+	c.client.Client.Timeout = 30 * time.Second
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -233,8 +233,6 @@ func (c *ListCmd) Run() error {
 		return err
 	}
 	fmt.Fprintln(c.out, "number of orders:", len(orders))
-	e := json.NewEncoder(c.out)
-	e.SetIndent("", "  ")
 	for _, o := range orders {
 		fmt.Fprintf(c.out, "id: %d name: %s email: %s\n", o.ID, o.Name, o.Email)
 	}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ identifier.
 type CLI struct {
 	Get     GetCmd     `cmd:"" help:"Get order by order ID"`
 	List    ListCmd    `cmd:"" help:"List first 50 orders with matching name"`
+	Meta    MetaCmd    `cmd:"" help:"List metafields for given order"`
 	Create  CreateCmd  `cmd:"" help:"Create order"`
 	Update  UpdateCmd  `cmd:"" help:"Update order"`
 	Merge   MergeCmd   `cmd:"" help:"Create or update order"`
@@ -62,6 +63,11 @@ type ListCmd struct {
 	Config
 	Order *goshopify.Order `optional:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order name to be listed (only name matters)"`
 	Name  string
+}
+
+type MetaCmd struct {
+	Config
+	ID int64 `arg:"" required:"" help:"order ID"`
 }
 
 type CreateCmd struct {
@@ -211,6 +217,14 @@ func (c *GetCmd) Run() error {
 		return err
 	}
 	return json.NewEncoder(c.out).Encode(order)
+}
+
+func (c *MetaCmd) Run() error {
+	meta, err := order.Meta(c.client, c.ID)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(c.out).Encode(meta)
 }
 
 func (c *VariantGetCmd) Run() error {

--- a/main.go
+++ b/main.go
@@ -97,7 +97,8 @@ type VariantCmd struct {
 
 type VariantGetCmd struct {
 	Config
-	ID int64 `arg:"" required:"" help:"variant ID"`
+	ID  int64  `optional:"" arg:"" help:"variant ID" xor:"id"`
+	SKU string `help:"variant SKU" xor:"id"`
 }
 
 type VariantCreateCmd struct {
@@ -159,7 +160,15 @@ func (c *GetCmd) Run() error {
 }
 
 func (c *VariantGetCmd) Run() error {
-	variant, err := c.client.Variant.Get(c.ID, nil)
+	id := c.ID
+	if id == 0 {
+		var err error
+		id, err = order.GetVariantIDBySKU(c.client, c.SKU)
+		if err != nil {
+			return err
+		}
+	}
+	variant, err := c.client.Variant.Get(id, nil)
 	if err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -90,6 +90,7 @@ func testConfig(t *testing.T, out io.Writer) *Config {
 		goshopify.WithLogger(logger),
 	}
 	client := goshopify.NewClient(goshopify.App{}, store, token, opts...)
+	client.Client.Timeout = 30 * time.Second
 	return &Config{
 		out:    out,
 		client: client,

--- a/order/order.go
+++ b/order/order.go
@@ -195,6 +195,16 @@ func Replace(client *goshopify.Client, order *goshopify.Order, createOpts Create
 	return Create(client, order, createOpts)
 }
 
+func Meta(client *goshopify.Client, orderID int64) ([]goshopify.Metafield, error) {
+	resource := goshopify.MetafieldsResource{}
+	path := fmt.Sprintf("orders/%d/metafields.json", orderID)
+	err := client.Get(path, &resource, nil)
+	if err != nil {
+		return nil, err
+	}
+	return resource.Metafields, nil
+}
+
 func GetIventoryLevels(client *goshopify.Client, inventoryItemID, variantID int64) ([]*InventoryLevel, error) {
 	if inventoryItemID == 0 {
 		variant, err := client.Variant.Get(variantID, nil)

--- a/order/order.go
+++ b/order/order.go
@@ -278,6 +278,42 @@ func GetVariantIDBySKU(client *goshopify.Client, sku string) (int64, error) {
 	return idFromGID(e[0].Node.ID)
 }
 
+func CustomerListByEmail(client *goshopify.Client, email string) ([]goshopify.Customer, error) {
+	if email == "" {
+		return nil, fmt.Errorf("email is empty")
+	}
+	query := struct {
+		Email string `url:"email"`
+	}{Email: email}
+	return client.Customer.Search(query)
+}
+
+func CustomerListByPhone(client *goshopify.Client, phone string) ([]goshopify.Customer, error) {
+	if phone == "" {
+		return nil, fmt.Errorf("phone is empty")
+	}
+	query := struct {
+		Phone string `url:"phone"`
+	}{Phone: phone}
+	return client.Customer.Search(query)
+}
+
+func CustomerMerge(client *goshopify.Client, customer *goshopify.Customer) (*goshopify.Customer, error) {
+	customers, err := CustomerListByEmail(client, customer.Email)
+	if err != nil {
+		return nil, err
+	}
+	if len(customers) > 1 {
+		return nil, fmt.Errorf("more than 1 customer found for email %q", customer.Email)
+	}
+	if len(customers) == 1 {
+		c := *customer
+		c.ID = customers[0].ID
+		return client.Customer.Update(c)
+	}
+	return client.Customer.Create(*customer)
+}
+
 func idFromGID(gid string) (int64, error) {
 	idx := strings.LastIndex(gid, "/")
 	if idx == -1 {

--- a/order/order.go
+++ b/order/order.go
@@ -183,6 +183,18 @@ func Delete(client *goshopify.Client, orderName string, opts DeleteOptions) ([]i
 	return deletedIDs, nil
 }
 
+func Replace(client *goshopify.Client, order *goshopify.Order, createOpts CreateOptions) (*goshopify.Order, error) {
+	delOpts := DeleteOptions{Unique: true}
+	ids, err := Delete(client, order.Name, delOpts)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) > 0 {
+		createOpts.Inventory = false // we have deleted one an order, presumably the inventory had been decremented for it.
+	}
+	return Create(client, order, createOpts)
+}
+
 func GetIventoryLevels(client *goshopify.Client, inventoryItemID, variantID int64) ([]*InventoryLevel, error) {
 	if inventoryItemID == 0 {
 		variant, err := client.Variant.Get(variantID, nil)

--- a/testdata/customer.json
+++ b/testdata/customer.json
@@ -1,0 +1,23 @@
+{
+  "email": "morgen3@example.com",
+  "first_name": "Mary",
+  "last_name": "Morgan",
+  "verified_email": true,
+  "orders_count": 2,
+  "accepts_marketing": true,
+  "default_address": {
+    "first_name": "Mary",
+    "last_name": "Morgan",
+    "address1": "12 Example St",
+    "city": "HappyTown",
+    "province": "Victoria",
+    "country": "Australia",
+    "zip": "3333",
+    "phone": "+6141234566",
+    "name": "Mary Morgan",
+    "province_code": "VIC",
+    "country_code": "AU",
+    "country_name": "Australia",
+    "default": true
+  }
+}

--- a/testdata/detailed_order.json
+++ b/testdata/detailed_order.json
@@ -1,0 +1,98 @@
+{
+  "name": "MWUXZxxxxx",
+  "email": "morgen@example.com",
+  "created_at": "2022-10-21T13:36:45+11:00",
+  "updated_at": "2022-10-21T13:36:46+11:00",
+  "processed_at": "2022-09-12T13:38:20+10:00",
+  "customer": {
+    "email": "morgen@example.comXX",
+    "first_name": "Mary",
+    "last_name": "Morgan",
+    "state": "disabled",
+    "verified_email": true,
+    "accepts_marketing": true,
+    "created_at": "2022-10-07T15:31:34+11:00",
+    "updated_at": "2022-10-21T13:36:46+11:00"
+  },
+  "billing_address": {
+    "address1": "12 Example St",
+    "city": "HappyTown",
+    "country": "Australia",
+    "country_code": "AU",
+    "first_name": "Mary",
+    "last_name": "Morgan",
+    "name": "Mary Morgan",
+    "phone": "+6141234566",
+    "province": "Victoria",
+    "province_code": "VIC",
+    "zip": "3333"
+  },
+  "shipping_address": {
+    "address1": "12 Example St",
+    "city": "HappyTown",
+    "country": "Australia",
+    "country_code": "AU",
+    "first_name": "Mary",
+    "last_name": "Morgan",
+    "latitude": -38.114263,
+    "longitude": 144.6681421,
+    "name": "Mary Morgan",
+    "phone": "+6141234566",
+    "province": "Victoria",
+    "province_code": "VIC",
+    "zip": "3333"
+  },
+  "currency": "AUD",
+  "total_price": "149.95",
+  "subtotal_price": "140",
+  "total_discounts": "0",
+  "total_line_items_price": "140",
+  "taxes_included": true,
+  "total_tax": "13.63",
+  "financial_status": "paid",
+  "buyer_accepts_marketing": true,
+  "line_items": [
+    {
+      "quantity": 1,
+      "price": "140",
+      "total_discount": "0",
+      "title": "Apple Puff Hood",
+      "variant_title": "Apple Puff Hood, M",
+      "name": "Apple Puff Hood - Apple Puff Hood, M",
+      "sku": "AAHA0922-M",
+      "taxable": true,
+      "fulfillment_service": "manual",
+      "requires_shipping": true,
+      "fulfillable_quantity": 1,
+      "tax_lines": [
+        {
+          "title": "GST",
+          "price": "12.73",
+          "rate": "0.1"
+        }
+      ]
+    }
+  ],
+  "shipping_lines": [
+    {
+      "title": "Domestic delivery",
+      "price": "9.95",
+      "code": "Domestic delivery",
+      "tax_lines": [
+        {
+          "title": "GST",
+          "price": "0.9",
+          "rate": "0.1"
+        }
+      ]
+    }
+  ],
+  "source_name": "SNEAKQL",
+  "tags": "SNEAKQL",
+  "payment_gateway_names": [
+    "manual (stripe)"
+  ],
+  "gateway": "manual (stripe)",
+  "confirmed": true,
+  "contact_email": "morgen@example.com"
+}


### PR DESCRIPTION
New features:

- Add `orderer customer get|create|update|delete|merge` commands
- Add `orderer replace` command
- Add `orderer meta` command
- Add variant look-up by SKU: `orderer variant get --sku=SKU`

Housekeeping:

- Remove dead code in main.go for JSON formatting 
- Increase HTTP client timeout from 10s to 30s
- Refactor `orderer delete` function into separate package
- Add another, more comprehensive order.json as testdata file