### PR TITLE
Optionally limit number of orders to be deleted

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ type GetCmd struct {
 type ListCmd struct {
 	Config
 	Order *goshopify.Order `optional:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order name to be listed (only name matters)"`
-	Name  string
+	Name  string           `help:"name of order(s) to be listed"`
 }
 
 type MetaCmd struct {

--- a/main.go
+++ b/main.go
@@ -104,9 +104,10 @@ type UpdateCmd struct {
 type DeleteCmd struct {
 	Config
 	Order  *goshopify.Order `optional:"" arg:"" type:"jsonfile" placeholder:"order.json" help:"File containing JSON encoded order to be deleted"`
-	Name   string
-	ID     int64
-	Unique bool `short:"u" help:"assert order name is used at most once"`
+	Max    int              `help:"maximum number of orders to be deleted. <= 50 (page size). default: no limit" default:"-1"`
+	Name   string           `help:"name of order(s) to be deleted"`
+	ID     int64            `help:"id of order to be deleted"`
+	Unique bool             `short:"u" help:"assert order name is used at most once"`
 }
 
 type ReplaceCmd struct {
@@ -424,7 +425,7 @@ func (c *DeleteCmd) Run() error {
 		fmt.Fprintln(c.out, "order deleted, ID:", c.ID)
 		return nil
 	}
-	opts := order.DeleteOptions{Unique: c.Unique, DryRun: true}
+	opts := order.DeleteOptions{Unique: c.Unique, DryRun: true, Max: c.Max}
 	orderIDs, err := order.Delete(c.client, c.OrderName(), opts)
 	if err != nil {
 		return err

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func TestRun(t *testing.T) {
 	order := testOrder(t, "testdata/order.json")
 	uniqueOrderName := fmt.Sprintf("%s-%d", order.Name, time.Now().UnixMilli()%10000) // to avoid collisions on concurrent runs
 	order.Name = uniqueOrderName
-	deleteCmd := DeleteCmd{Config: *cfg, Order: order}
+	deleteCmd := DeleteCmd{Config: *cfg, Order: order, Max: -1}
 	require.NoError(t, deleteCmd.Run())
 
 	got.Reset()
@@ -73,7 +73,7 @@ func TestRun(t *testing.T) {
 	require.Error(t, mergeCmd.Run())
 
 	got.Reset()
-	deleteCmd = DeleteCmd{Config: *cfg, Order: order}
+	deleteCmd = DeleteCmd{Config: *cfg, Order: order, Max: -1}
 	require.NoError(t, deleteCmd.Run())
 	want = "number of orders to delete: 2"
 	require.Equal(t, want, got.String()[:len(want)])

--- a/order/order.go
+++ b/order/order.go
@@ -25,6 +25,7 @@ type UpdateOptions struct {
 type DeleteOptions struct {
 	Unique bool
 	DryRun bool
+	Max    int
 }
 
 type MergeResult struct {
@@ -181,7 +182,10 @@ func Delete(client *goshopify.Client, orderName string, opts DeleteOptions) ([]i
 		return nil, fmt.Errorf("more than one order with name %q", orderName)
 	}
 	var deletedIDs []int64
-	for _, o := range orders {
+	for i, o := range orders {
+		if opts.Max != -1 && i >= opts.Max {
+			break
+		}
 		if opts.DryRun {
 			deletedIDs = append(deletedIDs, o.ID)
 			continue


### PR DESCRIPTION
Optionally limit number of orders to be deleted. This flag has been needed
when purging test stores except for the first X entries.

Improve help message for list command